### PR TITLE
code to remove sapper service workers

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,6 +11,15 @@
     return ""
   }
 
+  onMount(() => {
+    unregisterOldServiceWorkers()
+  })
+
+  function unregisterOldServiceWorkers(){
+    if (typeof navigator === "undefined") return
+    navigator.serviceWorker.getRegistrations().then( function(registrations) { for(let registration of registrations) { registration.unregister(); } });
+  }
+
 
 </script>
 


### PR DESCRIPTION
Sapper installed service workers that are preventing css from loading if a user previously visited the site.  Added code to remove all services workers installed for lamdenlink